### PR TITLE
Expand statusCodes, add 403/50x where appropriate.

### DIFF
--- a/__tests__/oauth_errors.spec.ts
+++ b/__tests__/oauth_errors.spec.ts
@@ -22,7 +22,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.InvalidClient({ 
+      const oe = new OauthErrors.InvalidClient({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -41,7 +41,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.InvalidGrant({ 
+      const oe = new OauthErrors.InvalidGrant({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -76,7 +76,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.InvalidScope({ 
+      const oe = new OauthErrors.InvalidScope({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -95,7 +95,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.UnauthorizedClient({ 
+      const oe = new OauthErrors.UnauthorizedClient({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -114,7 +114,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.UnauthorizedGrantType({ 
+      const oe = new OauthErrors.UnauthorizedGrantType({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -133,12 +133,12 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.AccessDenied({ 
+      const oe = new OauthErrors.AccessDenied({
         description: 'test',
         uri: 'http://test.com/error'
       })
       expect(oe).toBeInstanceOf(Oauth2Error)
-      expect(oe.statusCode).toBeTruthy()
+      expect(oe.statusCode).toBe(403)
       expect(oe.error).toBe('access_denied')
       expect(oe.error_description).toBeTruthy()
       expect(oe.error_uri).toBeTruthy()
@@ -152,7 +152,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.UnsupportedResponseType({ 
+      const oe = new OauthErrors.UnsupportedResponseType({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -171,12 +171,12 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.ServerError({ 
+      const oe = new OauthErrors.ServerError({
         description: 'test',
         uri: 'http://test.com/error'
       })
       expect(oe).toBeInstanceOf(Oauth2Error)
-      expect(oe.statusCode).toBeTruthy()
+      expect(oe.statusCode).toBe(500)
       expect(oe.error).toBe('server_error')
       expect(oe.error_description).toBeTruthy()
       expect(oe.error_uri).toBeTruthy()
@@ -189,7 +189,7 @@ describe('OauthErrors', () => {
     })
 
     it('should have the correct properties', () => {
-      const oe = new OauthErrors.TemporarilyUnavailable({ 
+      const oe = new OauthErrors.TemporarilyUnavailable({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -203,7 +203,7 @@ describe('OauthErrors', () => {
 
   describe('toString', () => {
     it('should be a string', () => {
-      const oe = new OauthErrors.InvalidClient({ 
+      const oe = new OauthErrors.InvalidClient({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -212,7 +212,7 @@ describe('OauthErrors', () => {
     })
 
     it('should not have `statusCode`', () => {
-      const oe = new OauthErrors.InvalidClient({ 
+      const oe = new OauthErrors.InvalidClient({
         description: 'test',
         uri: 'http://test.com/error'
       })
@@ -225,7 +225,7 @@ describe('OauthErrors', () => {
     })
 
     it('should not have `error_description`', () => {
-      const oe = new OauthErrors.InvalidClient({ 
+      const oe = new OauthErrors.InvalidClient({
         uri: 'http://test.com/error'
       })
       const s = oe.toString()
@@ -240,7 +240,7 @@ describe('OauthErrors', () => {
   describe('respond', () => {
     it('should respond with status `400` and correct properties', (done) => {
       const mockResponse = httpMocks.createResponse({ eventEmitter: EventEmitter })
-      const oe = new OauthErrors.InvalidClient({ 
+      const oe = new OauthErrors.InvalidClient({
         description: 'test',
         uri: 'http://test.com/error'
       })

--- a/src/errors/access_denied.ts
+++ b/src/errors/access_denied.ts
@@ -5,7 +5,8 @@ export class AccessDenied extends Oauth2Error {
     super({
       error: 'access_denied',
       error_description: params.description,
-      error_uri: params.uri
+      error_uri: params.uri,
+      statusCode: 403
     })
   }
 }

--- a/src/errors/server_error.ts
+++ b/src/errors/server_error.ts
@@ -5,7 +5,8 @@ export class ServerError extends Oauth2Error {
     super({
       error: 'server_error',
       error_description: params.description,
-      error_uri: params.uri
+      error_uri: params.uri,
+      statusCode: 500
     })
   }
 }

--- a/src/errors/temporarily_unavailable.ts
+++ b/src/errors/temporarily_unavailable.ts
@@ -5,7 +5,8 @@ export class TemporarilyUnavailable extends Oauth2Error {
     super({
       error: 'temporarily_unavailable',
       error_description: params.description,
-      error_uri: params.uri
+      error_uri: params.uri,
+      statusCode: 503
     })
   }
 }

--- a/src/oauth2_error.ts
+++ b/src/oauth2_error.ts
@@ -8,13 +8,14 @@ export class Oauth2Error extends Error {
   public error: string
   public error_description: string
   public error_uri: string
-  private statusCode: number = 400
+  public statusCode: number
 
   constructor (params: any) {
     super(params.error)
     this.error = params.error
     this.error_description = params.error_description
     this.error_uri = params.error_uri
+    this.statusCode = params.statusCode || 400
 
     Object.setPrototypeOf(this, Oauth2Error.prototype)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
     "node_modules",
     "lib",
     "__tests__",
-    "**/*.spec.*",
+    "**/*.spec.*"
   ]
 }


### PR DESCRIPTION
Expands `statusCode` selection beyond the current hardcoded 400.